### PR TITLE
Use a promise 'then' instead of the 'end' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@ module.exports = function(pg) {
         } else {
           const timing = req.miniprofiler.startTimeQuery('sql', config.toString());
           const query = pgQuery.call(this, config, values, callback);
-          query.on('end', function() {
+          query.then(function(r) {
             req.miniprofiler.stopTimeQuery(timing);
+            return r;
           });
           return query;
         }


### PR DESCRIPTION
Use a promise `then` instead of the 'end' event to hookup the `stopTimeQuery` action to the end of a query. This is necessary as pg's query object is not an event emitter anymore, but a promise.

Makes this work again if you are getting `TypeError: "on" is not a function`