### PR TITLE
Upgrade "pg" package to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniprofiler-pg",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A postgres provider for miniprofiler timing analysis",
   "main": "index.js",
   "scripts": {
@@ -38,7 +38,7 @@
     "istanbul": "^0.4.4",
     "miniprofiler": "^1.2.0",
     "mocha": "^2.5.3",
-    "pg": "^6.0.1",
+    "pg": "^7.6.1",
     "request": "^2.72.0"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -6,12 +6,12 @@ const server = require('./server.js');
 
 describe('Postgres Tests', function() {
 
-  before((done) => { server.listen(8080, done); });
-  after((done) => { server.close(done); });
+  before(done => { server.listen(8080, done); });
+  after(done => { server.close(done); });
 
-  for (const url of ['/pg-select', '/pg-select-event']) {
+  for (const url of ['/pg-select', '/pg-select-promise']) {
 
-    it(`Should profile postgres SELECT command for url '${url}'`, function(done) {
+    it(`Should profile postgres SELECT command for url '${url}'`, done => {
       request(`http://localhost:8080${url}`, (err, response) => {
         const ids = JSON.parse(response.headers['x-miniprofiler-ids']);
 
@@ -31,7 +31,7 @@ describe('Postgres Tests', function() {
 
   }
 
-  it('Should profile postgres NonQuery commands', function(done) {
+  it('Should profile postgres NonQuery commands', done => {
     request('http://localhost:8080/insert', (err, response) => {
       const ids = JSON.parse(response.headers['x-miniprofiler-ids']);
 
@@ -49,7 +49,7 @@ describe('Postgres Tests', function() {
     });
   });
 
-  it('should not break pg usage on unprofiled routes', function(done) {
+  it('should not break pg usage on unprofiled routes', done => {
     request('http://localhost:8080/unprofiled', (err, response, body) => {
       expect(response.headers).to.not.include.keys('x-miniprofiler-ids');
       expect(body).to.be.equal('123456');


### PR DESCRIPTION
Use a promise `then` instead of the `end` event to hookup the stopTimer
action to the end of a query. This is necessary as pg's query object is
not an event emitter anymore, but a promise.

See https://node-postgres.com/guides/upgrading